### PR TITLE
travis: change extra dpdk version test to use v18.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -205,7 +205,7 @@ jobs:
                               -e ODP_CONFIG_FILE=/odp/platform/linux-generic/test/packet_align.conf
                               ${DOCKER_NAMESPACE}/travis-odp-${OS}-${ARCH} /odp/scripts/ci/check_pktio.sh
                 - stage: test
-                  env: TEST=dpdk-19.11
+                  env: TEST=dpdk-18.11
                   install:
                           - true
                   compiler: gcc
@@ -215,7 +215,7 @@ jobs:
                               -v `pwd`:/odp --shm-size 8g
                               -e CC="${CC}"
                               -e CONF=""
-                              ${DOCKER_NAMESPACE}/travis-odp-${OS}-${ARCH}-dpdk_19.11 /odp/scripts/ci/check.sh
+                              ${DOCKER_NAMESPACE}/travis-odp-${OS}-${ARCH}-dpdk_18.11 /odp/scripts/ci/check.sh
                 - stage: test
                   env: TEST=distcheck
                   compiler: gcc

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -171,8 +171,8 @@ Prerequisites for building the OpenDataPlane (ODP) API
 
 3.4 DPDK packet I/O support (optional)
 
-   Use DPDK for ODP packet I/O. Currently supported DPDK versions are v18.11
-   and v19.11.
+   Use DPDK for ODP packet I/O. Currently supported DPDK versions are v19.11
+   (recommended) and v18.11.
 
    Note: only packet I/O is accelerated with DPDK. Use
         https://github.com/OpenDataPlane/odp-dpdk.git
@@ -191,7 +191,7 @@ Prerequisites for building the OpenDataPlane (ODP) API
    $ sudo apt-get install dpdk-dev
 
 3.4.2 Built DPDK from src
-   git clone --branch=18.11 http://dpdk.org/git/dpdk-stable dpdk
+   git clone --branch=19.11 http://dpdk.org/git/dpdk-stable dpdk
 
    #Make and edit DPDK configuration
    TARGET="x86_64-native-linuxapp-gcc"

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -191,23 +191,22 @@ Prerequisites for building the OpenDataPlane (ODP) API
    $ sudo apt-get install dpdk-dev
 
 3.4.2 Built DPDK from src
-   git clone --branch=19.11 http://dpdk.org/git/dpdk-stable dpdk
+   $ git clone --branch=19.11 http://dpdk.org/git/dpdk-stable dpdk
 
-   #Make and edit DPDK configuration
-   TARGET="x86_64-native-linuxapp-gcc"
-   make config T=${TARGET} O=${TARGET}
-   pushd ${TARGET}
+   # Make and edit DPDK configuration
+   $ export TARGET="x86_64-native-linuxapp-gcc"
+   $ make config T=${TARGET} O=${TARGET}
+   $ pushd ${TARGET}
 
-   #To use I/O without DPDK supported NIC's enable pcap pmd:
-   sed -ri 's,(CONFIG_RTE_LIBRTE_PMD_PCAP=).*,\1y,' .config
-   popd
+   # To use I/O without DPDK supported NIC's enable pcap pmd:
+   $ sed -ri 's,(CONFIG_RTE_LIBRTE_PMD_PCAP=).*,\1y,' .config
+   $ popd
 
-   #Build DPDK
-   make build O=${TARGET} EXTRA_CFLAGS="-fPIC"
-   make install O=${TARGET} DESTDIR=${TARGET}
+   # Build DPDK
+   $ make install T=${TARGET} EXTRA_CFLAGS="-fPIC" DESTDIR=./install
 
-   #compile ODP
-   ./configure --with-dpdk-path=<dpdk_install_dir>
+   # Compile ODP
+   $ ./configure --with-dpdk-path=<dpdk_install_dir>
 
 3.4.3 Setup system
 


### PR DESCRIPTION
The default DPDK version in ODP Docker containers has been updated to
v19.11.

Signed-off-by: Matias Elo <matias.elo@nokia.com>