### PR TITLE
github_ci: update hosted runner ubuntu version

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -24,7 +24,7 @@ jobs:
       if: github.event_name == 'pull_request'
       env:
         CHECKPATCH_COMMAND: ./scripts/checkpatch.pl
-      uses: webispy/checkpatch-action@v7
+      uses: webispy/checkpatch-action@v8
 
     - name: Check push
       if: github.event_name == 'push' && github.ref != 'refs/heads/master'


### PR DESCRIPTION
Update GitHub hoster runner to Ubuntu 20.04 for newer Git version.

Signed-off-by: Matias Elo <matias.elo@nokia.com>